### PR TITLE
Create PyInstaller onefile packages

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,35 @@
+name: PyInstaller packages
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  package:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-11, ubuntu-20.04, windows-2019]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip wheel
+        pip install -r requirements.txt
+        pip install pyinstaller
+    - name: Generate PyInstaller package
+      shell: bash
+      run: |
+        pyinstaller resolve.spec
+        cp LICENSE README.md dist/
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: resolve-${{ matrix.os }}
+        path: dist/

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.8"
     - name: Install dependencies
       shell: bash
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,8 @@ __pycache__
 .idea
 .ve
 .virtualenv
+.venv/
 test_index
 mp3
+/build/
+/dist/

--- a/resolve.spec
+++ b/resolve.spec
@@ -1,0 +1,44 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+block_cipher = None
+
+
+a = Analysis(
+    ['resolve.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    [],
+    name='resolve',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)


### PR DESCRIPTION
This is a first step towards packaging this tool for different operating systems.

Currently this creates a PyInstaller onefile package.

Advantages:

- You get a single executable (per OS) that can be run. So on Windows there is a single `resolve.exe` the user can copy where they want it and run it from command line.
- We don't necessarily need an installer, most users should be able to handle this if they can handle running command line tools

Disadvantages:

- The loading times are rather bad, as the file contains all the required libraries and Python modules, which need to be extracted on run. Especially for a CLI tool this is bad.
- People still have to copy it

Alternatively we could use PyInstaller to package not in onefile mode. Than you get a directory containing the `resolve.exe` and all the dependencies (full Python and all required modules). That runs quickly, but maybe more difficult to handle for user. To make this easier we could package this all up with a installer that copies the files somehwere and maybe even adapts the Windows ` PATH`  variable. IMHO all options to generate Windows installers are a PITA. Picard uses NSIS. It uses a strange scripting language, but at least I have some experience. Not very keen on the work, to be honest :)

Another alternative is just packaging this as a pip package and make it available on pypi (no PyInstaller involved). Then users will need to install Python first, but afterwards they can `pip install listenbrainz-content-resolver`  and run `resolve` afterwards. Probably the easiest solution overall.