### PR TITLE
Add support for opus format

### DIFF
--- a/lb_content_resolver/database.py
+++ b/lb_content_resolver/database.py
@@ -9,9 +9,9 @@ import peewee
 
 from lb_content_resolver.model.database import db, setup_db
 from lb_content_resolver.model.recording import Recording
-from lb_content_resolver.formats import mp3, m4a, flac, ogg_vorbis, wma
+from lb_content_resolver.formats import mp3, m4a, flac, ogg_opus, ogg_vorbis, wma
 
-SUPPORTED_FORMATS = ["flac", "ogg", "mp3", "m4a", "wma"]
+SUPPORTED_FORMATS = ["flac", "ogg", "opus", "mp3", "m4a", "wma"]
 
 
 class Database:
@@ -169,6 +169,8 @@ class Database:
             mdata = flac.read(file_path)
         elif format == "ogg":
             mdata = ogg_vorbis.read(file_path)
+        elif format == "opus":
+            mdata = ogg_opus.read(file_path)
         elif format == "m4a":
             mdata = m4a.read(file_path)
         elif format == "wma":

--- a/lb_content_resolver/formats/ogg_opus.py
+++ b/lb_content_resolver/formats/ogg_opus.py
@@ -1,0 +1,27 @@
+import mutagen
+import mutagen.oggopus
+
+from lb_content_resolver.formats.tag_utils import get_tag_value, extract_track_number
+
+
+def read(file):
+
+    tags = None
+    try:
+        tags = mutagen.oggopus.OggOpus(file)
+    except mutagen.oggous.HeaderNotFoundError:
+        print("Cannot read metadata from file %s" % file)
+        return None
+
+    mdata = {}
+    mdata["artist_name"] = get_tag_value(tags, "artist")
+    mdata["artist_sortname"] = get_tag_value(tags, "artistsort")
+    mdata["release_name"] = get_tag_value(tags, "album")
+    mdata["recording_name"] = get_tag_value(tags, "title")
+    mdata["track_num"] = extract_track_number(get_tag_value(tags, "tracknumber"))
+    mdata["artist_mbid"] = get_tag_value(tags, "musicbrainz_artistid", "")
+    mdata["recording_mbid"] = get_tag_value(tags, "musicbrainz_releasetrackid", "")
+    mdata["release_mbid"] = get_tag_value(tags, "musicbrainz_albumartistid", "")
+    mdata["duration"] = int(tags.info.length * 1000)
+
+    return mdata


### PR DESCRIPTION
This essentially is a copy of the vorbis format.
I tried handling both with a common reader, though it seemed like mutagen does not support that as easily as I thought.
It might be possible to merge the flac, vorbis and opus formats into one handler, because their code is mostly the same, though I did not attempt to do this.

Also, thanks for this project! I was looking for exactly this.
