### PR TITLE
Make the list of music dirs a list, not tuple

### DIFF
--- a/config.py.sample
+++ b/config.py.sample
@@ -10,7 +10,7 @@ SUBSONIC_PORT = 4533
 # List of music directories to scan by default
 # If paths are passed to scan command, this list is ignored.
 # Invalid directories are skipped.
-MUSIC_DIRECTORIES = (
+MUSIC_DIRECTORIES = [
     'My/Music/Directory 1',
     'My/Music/Directory 2',
-)
+]


### PR DESCRIPTION
If the user has only one directory for music and forgets to add a tailing comma, the single path gets chopped into single characters and the program scans from '/'. Not so great. Making a list avoids this problem.