### PR TITLE
Unresolved recordings cleanup

### DIFF
--- a/lb_content_resolver/unresolved_recording.py
+++ b/lb_content_resolver/unresolved_recording.py
@@ -133,8 +133,6 @@ class UnresolvedRecordingTracker:
             been added to the DB.
         """
 
-        #TODO: add MBID lookup to the resolution process. heh.
-
         query = f"""DELETE FROM unresolved_recording
                           WHERE recording_mbid in (
                                  SELECT recording.recording_mbid

--- a/lb_content_resolver/unresolved_recording.py
+++ b/lb_content_resolver/unresolved_recording.py
@@ -56,6 +56,10 @@ class UnresolvedRecordingTracker:
             Return up to num_item releases.
         """
 
+        # First call cleanup, which removes recordings that may have been recently
+        # added
+        self.cleanup()
+
         query = f"""SELECT recording_mbid
                          , lookup_count
                       FROM unresolved_recording"""
@@ -122,3 +126,21 @@ class UnresolvedRecordingTracker:
             for rec in release["recordings"]:
                 print("   %-57s %d lookups" % (rec["recording_name"][:56], rec["lookup_count"]))
             print()
+
+    def cleanup(self):
+        """
+            Check the local collection and remove any recordings from unresolved recordings that have
+            been added to the DB.
+        """
+
+        #TODO: add MBID lookup to the resolution process. heh.
+
+        query = f"""DELETE FROM unresolved_recording
+                          WHERE recording_mbid in (
+                                 SELECT recording.recording_mbid
+                                   FROM recording
+                                   JOIN unresolved_recording
+                                     ON recording.recording_mbid = unresolved_recording.recording_mbid
+                                 )"""
+
+        cursor = db.execute_sql(query)

--- a/resolve.py
+++ b/resolve.py
@@ -110,6 +110,10 @@ def scan(db_file, music_dirs):
         music_dirs = music_directories_from_config()
     db.scan(music_dirs)
 
+    # Remove any recordings from the unresolved recordings that may have just been added.
+    urt = UnresolvedRecordingTracker()
+    releases = urt.cleanup()
+
 
 @click.command()
 @click.option("-d", "--db_file", help="Database file for the local collection", required=False, is_flag=False)


### PR DESCRIPTION
This PR improves two things:

1. Use MBID as the first matching technique when resolving tracks.
2. Remove unresolved tracks that have just been added to the database after each scan.

Also improve the feedback and give the user feedback if the match was an MBID match or a fuzzy match.