### PR TITLE
Add --verbose option to duplicates command

### DIFF
--- a/lb_content_resolver/duplicates.py
+++ b/lb_content_resolver/duplicates.py
@@ -2,6 +2,8 @@ import os
 import json
 from collections import defaultdict
 import datetime
+import hashlib
+import mutagen
 import sys
 
 import peewee
@@ -50,19 +52,63 @@ class FindDuplicates:
                        HAVING cnt > 1 
                      ORDER BY cnt DESC, artist_name, recording_name"""
 
-        return [ (r[0], r[1], r[2], r[3], json.loads(r[4]), r[5]) for r in db.execute_sql(query).fetchall() ]
+        for r in db.execute_sql(query).fetchall():
+            yield (r[0], r[1], r[2], r[3], json.loads(r[4]), r[5])
 
-    
-    def print_duplicate_recordings(self, include_different_releases=True):
+    @staticmethod
+    def sha1sum(filename):
+        h = hashlib.sha1()
+        mv = memoryview(bytearray(128*1024))
+        with open(filename, 'rb', buffering=0) as f:
+            while n := f.readinto(mv):
+                h.update(mv[:n])
+        return h.hexdigest()
+
+    def print_duplicate_recordings(self, include_different_releases=True, verbose=False):
 
         total = 0
-        dups = self.get_duplicate_recordings(include_different_releases)
-        for dup in dups:
+        recordings_count = 0
+
+        def indent(n, s=''):
+            return ' ' * (4 * n) + str(s)
+
+        def print_error(e):
+            print(indent(2, "error: %s" % e))
+
+        def print_info(title, content):
+            print(indent(2, "%s: %s" % (title, content)))
+
+        for dup in self.get_duplicate_recordings(include_different_releases):
+            recordings_count += 1
             print("%d duplicates of '%s' by '%s'" % (dup[5], dup[0], dup[2]))
-            for f in dup[4]:
-                print("   %s" % f)
+            for file_path in dup[4]:
+                print(indent(1, file_path))
+                if verbose:
+                    error = False
+                    try:
+                        file_stats = os.stat(file_path)
+                        print_info("size", "%d bytes" % file_stats.st_size)
+                    except Exception as e:
+                        print_error(e)
+                        error = True
+
+                    if not error:
+                        try:
+                            print_info("sha1", self.sha1sum(file_path))
+                        except Exception as e:
+                            print_error(e)
+                            error = True
+
+                    if not error:
+                        try:
+                            mf = mutagen.File(file_path)
+                            print_info("format", mf.info.pprint())
+                        except mutagen.MutagenError as e:
+                            print_error(e)
+
                 total += 1
             print()
 
         print()
-        print("%d recordings had a total of %d duplicates." % (len(dups), total))
+        print("%d recordings had a total of %d duplicates." %
+              (recordings_count, total))

--- a/resolve.py
+++ b/resolve.py
@@ -205,13 +205,14 @@ def top_tags(db_file, count):
 @click.command()
 @click.option("-d", "--db_file", help="Database file for the local collection", required=False, is_flag=False)
 @click.option('-e', '--exclude-different-release', required=False, default=False, is_flag=True)
-def duplicates(db_file, exclude_different_release):
-    "Print all the tracks in the DB that are duplciated as per recording_mbid"
+@click.option('-v', '--verbose', help="Display extra info about found files", required=False, default=False, is_flag=True)
+def duplicates(db_file, exclude_different_release, verbose):
+    "Print all the tracks in the DB that are duplicated as per recording_mbid"
     db_file = db_file_check(db_file)
     db = Database(db_file)
     db.open()
     fd = FindDuplicates(db)
-    fd.print_duplicate_recordings(exclude_different_release)
+    fd.print_duplicate_recordings(exclude_different_release, verbose)
 
 
 @click.command()


### PR DESCRIPTION
For each potential duplicated file, it will diplay size, sha1 checksum and audio format infos. Without this new option, the output remains unchanged.


Exemple of output:

```
2 duplicates of 'Patalo' by 'Têtes Raides'
    /media/zas/2TB_RAID11/Musique/tagged_olivier/Têtes Raides/20 ans de Ginette/12 Patalo.mp3
        size: 4668034 bytes
        sha1: 1fc3eba4996ee83d02664032ca6a665b508075e6
        format: MPEG 1 layer 3, 128000 bps (CBR?), 44100 Hz, 2 chn, 288.22 seconds
    /media/zas/2TB_RAID11/Musique/tagged_olivier/Têtes Raides/Gratte poil/15 Patalo.mp3
        size: 7017631 bytes
        sha1: 20619841ff9af5af667f419f409799d1495492e2
        format: MPEG 1 layer 3, 192000 bps (CBR?), 44100 Hz, 2 chn, 289.76 seconds
```

It also takes care of files that disappeared, and report an error if not found (or unreadable).

`get_duplicate_recordings()` now yields results instead of building a list.