### PR TITLE
Reduce code redundancy, simplify formats

### DIFF
--- a/lb_content_resolver/formats/flac.py
+++ b/lb_content_resolver/formats/flac.py
@@ -4,14 +4,11 @@ import mutagen.flac
 from lb_content_resolver.formats.tag_utils import get_tag_value, extract_track_number
 
 
-def read(file):
+EXTENSIONS = {'.flac'}
+READER = mutagen.flac.FLAC
 
-    tags = None
-    try:
-        tags = mutagen.flac.FLAC(file)
-    except mutagen.flac.HeaderNotFoundError:
-        print("Cannot read metadata from file %s" % file.encode("utf-8"))
-        return None
+
+def get_metadata(tags):
 
     mdata = {}
     mdata["artist_name"] = get_tag_value(tags, "artist")

--- a/lb_content_resolver/formats/m4a.py
+++ b/lb_content_resolver/formats/m4a.py
@@ -4,14 +4,11 @@ import mutagen.mp4
 from lb_content_resolver.formats.tag_utils import get_tag_value, extract_track_number
 
 
-def read(file):
+EXTENSIONS = {'.m4a', '.m4b', '.m4p', '.m4v', '.m4r', '.mp4'}
+READER = mutagen.mp4.MP4
 
-    tags = None
-    try:
-        tags = mutagen.mp4.MP4(file)
-    except mutagen.mp4.MutagenError:
-        print("Cannot read metadata from file %s" % file)
-        return None
+
+def get_metadata(tags):
 
     mdata = {}
     mdata["artist_name"] = get_tag_value(tags, "©ART")
@@ -26,6 +23,7 @@ def read(file):
     mdata["duration"] = int(tags.info.length * 1000)
 
     return mdata
+
 
 def get_and_decode(tags, tag_name):
     tag_value = get_tag_value(tags, tag_name)

--- a/lb_content_resolver/formats/mp3.py
+++ b/lb_content_resolver/formats/mp3.py
@@ -4,14 +4,11 @@ import mutagen.mp3
 from lb_content_resolver.formats.tag_utils import get_tag_value, extract_track_number
 
 
-def read(file):
+EXTENSIONS = {'.mp3', '.mp2', '.m2a'}
+READER = mutagen.mp3.MP3
 
-    tags = None
-    try:
-        tags = mutagen.mp3.MP3(file)
-    except mutagen.mp3.HeaderNotFoundError:
-        print("Cannot read metadata from file %s" % file.encode("utf-8"))
-        return None
+
+def get_metadata(tags):
 
     mdata = {}
     if "TPE1" in tags:

--- a/lb_content_resolver/formats/ogg_opus.py
+++ b/lb_content_resolver/formats/ogg_opus.py
@@ -4,14 +4,11 @@ import mutagen.oggopus
 from lb_content_resolver.formats.tag_utils import get_tag_value, extract_track_number
 
 
-def read(file):
+EXTENSIONS = {'.opus'}
+READER = mutagen.oggopus.OggOpus
 
-    tags = None
-    try:
-        tags = mutagen.oggopus.OggOpus(file)
-    except mutagen.oggous.HeaderNotFoundError:
-        print("Cannot read metadata from file %s" % file)
-        return None
+
+def get_metadata(tags):
 
     mdata = {}
     mdata["artist_name"] = get_tag_value(tags, "artist")

--- a/lb_content_resolver/formats/ogg_vorbis.py
+++ b/lb_content_resolver/formats/ogg_vorbis.py
@@ -4,14 +4,11 @@ import mutagen.oggvorbis
 from lb_content_resolver.formats.tag_utils import get_tag_value, extract_track_number
 
 
-def read(file):
+EXTENSIONS = {'.ogg'}
+READER = mutagen.oggvorbis.OggVorbis
 
-    tags = None
-    try:
-        tags = mutagen.oggvorbis.OggVorbis(file)
-    except mutagen.oggvorbis.HeaderNotFoundError:
-        print("Cannot read metadata from file %s" % file)
-        return None
+
+def get_metadata(tags):
 
     mdata = {}
     mdata["artist_name"] = get_tag_value(tags, "artist")

--- a/lb_content_resolver/formats/wma.py
+++ b/lb_content_resolver/formats/wma.py
@@ -4,14 +4,11 @@ import mutagen.asf
 from lb_content_resolver.formats.tag_utils import get_tag_value, extract_track_number
 
 
-def read(file):
+EXTENSIONS = {'.wma'}
+READER = mutagen.asf.ASF
 
-    tags = None
-    try:
-        tags = mutagen.asf.ASF(file)
-    except mutagen.asf.HeaderNotFoundError:
-        print("Cannot read metadata from file %s" % file)
-        return None
+
+def get_metadata(tags):
 
     mdata = {}
     mdata["artist_name"] = str(get_tag_value(tags, "Author"))


### PR DESCRIPTION
- simplify supported format list
- define list of matching extensions inside each format file; as <format>.EXTENSIONS
- rename <format>.read() to <format>.get_metadata() as it doesn't read file anymore
- read method is provided by <format>.READER constant
- calling code was updated to reflect those changes