### PR TITLE
Skip directories if they didn't change (mtime) since last run

### DIFF
--- a/lb_content_resolver/model/directory.py
+++ b/lb_content_resolver/model/directory.py
@@ -1,0 +1,18 @@
+from peewee import *
+from lb_content_resolver.model.database import db
+
+
+class Directory(Model):
+    """
+    Basic metadata information about a recording on disk (a track).
+    """
+
+    class Meta:
+        database = db
+
+    id = AutoField()
+    dir_path = TextField(null=False, unique=True)
+    mtime = TimestampField(null=False)
+
+    def __repr__(self):
+        return "<Directory('%s')>" % self.dir_path


### PR DESCRIPTION
- create a new table to store directories mtime
- os.stat() each directory and store this info in table
- use that to skip non-modified directories

It should be noted directory's mtime isn't modified if file's owner, group, mode, atime, ctime, mtime are modified. But only when file are modified, created, deleted (including links or directories).