### PR TITLE
Fix subsonic on rpi

### DIFF
--- a/lb_content_resolver/subsonic.py
+++ b/lb_content_resolver/subsonic.py
@@ -140,7 +140,7 @@ class SubsonicDatabase(Database):
         cursor = db.connection().cursor()
         with db.atomic() as transaction:
 
-            placeholders = ",".join(("?", ) * len(recording_index.keys()))
+            placeholders = ",".join(("?", ) * len(recording_index))
             cursor.execute("""SELECT recording_id
                                 FROM recording_subsonic
                                WHERE recording_id in (%s)""" % placeholders, tuple(recording_index.keys()))

--- a/lb_content_resolver/subsonic.py
+++ b/lb_content_resolver/subsonic.py
@@ -135,16 +135,34 @@ class SubsonicDatabase(Database):
             Updates recording_id, subsonic_id, last_update
         """
 
-        recordings = [(r[0], r[1], datetime.datetime.now()) for r in recordings]
+        recording_index = { r[0]:r[1] for r in recordings }
 
         cursor = db.connection().cursor()
         with db.atomic() as transaction:
-            cursor.executemany(
-                """INSERT INTO recording_subsonic (recording_id, subsonic_id, last_updated)
-                                        VALUES (?, ?, ?)
-                     ON CONFLICT DO UPDATE SET recording_id = excluded.recording_id
-                                             , subsonic_id = excluded.subsonic_id
-                                             , last_updated = excluded.last_updated""", recordings)
+
+            placeholders = ",".join(("?", ) * len(recording_index.keys()))
+            cursor.execute("""SELECT recording_id
+                                FROM recording
+                               WHERE recording_id in (%s)""" % placeholders, tuple(recording_index.keys()))
+            existing_ids = [ row[0] for row in cursor.fetchall() ]
+            existing_recordings = [ 
+            new_recordings
+
+
+
+            = [(r[0], r[1], datetime.datetime.now()) for r in recordings]
+
+        # This concise query does the same as above. But older versions of python/sqlite on Raspberry Pis 
+        # don't support upserts yet. :(
+        #recordings = [(r[0], r[1], datetime.datetime.now()) for r in recordings]
+        #cursor.executemany(
+        #    """INSERT INTO recording_subsonic (recording_id, subsonic_id, last_updated)
+        #                            VALUES (?, ?, ?)
+        #         ON CONFLICT DO UPDATE SET recording_id = excluded.recording_id
+        #                                 , subsonic_id = excluded.subsonic_id
+        #                                 , last_updated = excluded.last_updated""", recordings)
+
+
 
     def upload_playlist(self, jspf):
         """


### PR DESCRIPTION
UPSERT support isn't widely available yet, such as on recent Raspberry Pi distros. Falling back to doing the manual updates to the DB, but at some point later, we should revert this code and go back to the better single query.