### PR TITLE
Update deps

### DIFF
--- a/lb_content_resolver/py_sonic_fix.py
+++ b/lb_content_resolver/py_sonic_fix.py
@@ -1,0 +1,27 @@
+from libsonic import Connection
+
+
+class FixedConnection(Connection):
+    """
+        This hack enables album ids to strings -- a PR has been submitted, but in case
+        it doesn't get accepted in a timely manner, this workaround allows us to 
+        continue.
+    """
+
+    def getAlbumInfo2(self, aid):
+        """
+        since 1.14.0
+
+        Same as getAlbumInfo, but uses ID3 tags
+
+        aid:int     The album ID    
+        """
+        methodName = 'getAlbumInfo2'
+        viewName = '%s.view' % methodName
+
+        # The release version has an int() cast here
+        q = {'id': aid}
+        req = self._getRequest(viewName, q)
+        res = self._doInfoReq(req)
+        self._checkStatus(res)
+        return res

--- a/lb_content_resolver/subsonic.py
+++ b/lb_content_resolver/subsonic.py
@@ -3,7 +3,6 @@ import os
 import sys
 from uuid import UUID
 
-import libsonic
 import peewee
 from tqdm import tqdm
 
@@ -11,6 +10,7 @@ from lb_content_resolver.database import Database
 from lb_content_resolver.model.database import db
 from lb_content_resolver.model.recording import Recording, FileIdType
 from lb_content_resolver.utils import bcolors
+from lb_content_resolver.py_sonic_fix import FixedConnection
 
 
 class SubsonicDatabase(Database):
@@ -48,7 +48,7 @@ class SubsonicDatabase(Database):
 
         print("[ connect to subsonic ]")
 
-        return libsonic.Connection(
+        return FixedConnection(
             self.config.SUBSONIC_HOST,
             self.config.SUBSONIC_USER,
             self.config.SUBSONIC_PASSWORD,
@@ -94,7 +94,7 @@ class SubsonicDatabase(Database):
             # Some servers might already include the MBID in the list or album response
             album_mbid = album_info.get("musicBrainzId", album.get("musicBrainzId"))
             if not album_mbid:
-                album_info2 = conn.getAlbumInfo2(id=album["id"])
+                album_info2 = conn.getAlbumInfo2(aid=album["id"])
                 try:
                     album_mbid = album_info2["albumInfo"]["musicBrainzId"]
                 except KeyError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ nmslib==2.1.1
 regex==2023.6.3
 lb_matching_tools@git+https://github.com/metabrainz/listenbrainz-matching-tools.git@v-2023-07-19.0
 requests
-py-sonic@git+https://github.com/mayhem/py-sonic.git@int-vs-string
+py-sonic==1.0.0
 tqdm
 troi==2024.1.26.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,4 @@ lb_matching_tools@git+https://github.com/metabrainz/listenbrainz-matching-tools.
 requests
 py-sonic@git+https://github.com/mayhem/py-sonic.git@int-vs-string
 tqdm
-troi@git+https://github.com/metabrainz/troi-recommendation-playground.git@lb-local
-icecream
+troi==2024.1.26.0


### PR DESCRIPTION
The PR fixes two things:

1. The github pinned version of troi is now a simple install since troi landed on pypi.
2. Derive a class with fixed getAbum2 call to avoid having a custom version of py-sonic. PR has been opened upstream, but this fix allows us to continue immediately.