### PR TITLE
Refactoring & improving playlist saving

### DIFF
--- a/lb_content_resolver/content_resolver.py
+++ b/lb_content_resolver/content_resolver.py
@@ -204,6 +204,8 @@ class ContentResolver:
                 target.musicbrainz["filename"] = local_recording["file_id"]
             if local_recording["file_id_type"] == FileIdType.SUBSONIC_ID:
                 target.musicbrainz["subsonic_id"] = local_recording["file_id"]
+            if local_recording["duration"] is not None:
+                target.duration = local_recording["duration"]
 
             print(bcolors.OKGREEN + ("%-5s" % hit["method"]) + bcolors.ENDC +
                   "  %-40s %-40s %-40s" % (artist_recording["recording_name"][:39], "",

--- a/lb_content_resolver/content_resolver.py
+++ b/lb_content_resolver/content_resolver.py
@@ -6,12 +6,14 @@ from uuid import UUID
 import peewee
 
 from lb_content_resolver.model.database import db, setup_db
-from lb_content_resolver.model.recording import Recording
+from lb_content_resolver.model.recording import Recording, FileIdType
 from lb_content_resolver.unresolved_recording import UnresolvedRecordingTracker
 from lb_content_resolver.fuzzy_index import FuzzyIndex
 from lb_matching_tools.cleaner import MetadataCleaner
 from lb_content_resolver.playlist import read_jspf_playlist
 from lb_content_resolver.utils import bcolors
+from troi.playlist import PlaylistElement
+from troi import Playlist
 
 
 class ContentResolver:
@@ -144,70 +146,76 @@ class ContentResolver:
 
         return artist_recording_data
 
-    def resolve_playlist(self, match_threshold, recordings=None, jspf_playlist=None):
+    def resolve_playlist(self, match_threshold, playlist):
         """
-            Given a JSPF playlist or a list of troi recordings, resolve tracks and return a list of resolved recordings.
+            Given a Troi playlist element, resolve tracks in the given playlist and update the playlist accordingly.
             threshold is a value between 0 and 1.0 for the percentage score required before a track is matched.
         """
 
-        if recordings is None and jspf_playlist is None:
-            raise ValueError("Either recordings or jspf_playlist must be passed.")
-
         artist_recording_data = []
-        if jspf_playlist is not None:
-            if len(jspf_playlist["playlist"]["track"]) == 0:
-                return []
-            for i, track in enumerate(jspf_playlist["playlist"]["track"]):
-                artist_recording_data.append({"artist_name": track["creator"],
-                                              "recording_name": track["title"],
-                                              "recording_mbid": track["identifier"][34:]})
-        else:
-            if not recordings:
-                return []
-            for rec in recordings:
-                artist_recording_data.append({"artist_name": rec.artist.name,
-                                              "recording_name": rec.name,
-                                              "recording_mbid": rec.mbid})
+        # Check to make sure we have at least one recording
+        try:
+            _ = playlist.playlists[0].recordings[0]
+        except (KeyError, IndexError):
+            return playlist
+
+        for rec in playlist.playlists[0].recordings:
+            artist_recording_data.append({"artist_name": rec.artist.name,
+                                          "recording_name": rec.name,
+                                          "recording_mbid": rec.mbid})
 
         # See what we can resolve using MBIDs
         artist_recording_data = self.resolve_recording_by_mbid(artist_recording_data)
 
         self.build_index()
 
+        # Now see what we can resolve using fuzzy index
         hits = self.resolve_recordings(artist_recording_data, match_threshold)
         hit_index = {hit["index"]: hit for hit in hits}
 
+        # load local recordings according to fuzzy search results
         recording_ids = [r["recording_id"] for r in hits]
-        recordings = Recording \
+        local_recordings = Recording \
             .select(Recording) \
             .where(Recording.id.in_(recording_ids)) \
             .dicts()
-        rec_index = {r["id"]: r for r in recordings}
+
+        # Build index based on recording.id
+        rec_index = {r["id"]: r for r in local_recordings}
 
         print("       %-40s %-40s %-40s" % ("RECORDING", "RELEASE", "ARTIST"))
-        results = [None] * len(artist_recording_data)
         unresolved_recordings = []
+        target_recordings = playlist.playlists[0].recordings
+        resolved = 0
+        failed = 0
         for i, artist_recording in enumerate(artist_recording_data):
             if i not in hit_index:
                 print(bcolors.FAIL + "FAIL " + bcolors.ENDC + "  %-40s %-40s %-40s" % (artist_recording["recording_name"][:39], "",
                                                                                        artist_recording["artist_name"][:39]))
                 unresolved_recordings.append(artist_recording["recording_mbid"])
+                failed += 1
                 continue
 
             hit = hit_index[i]
-            rec = rec_index[hit["recording_id"]]
-            results[hit["index"]] = rec
+            local_recording = rec_index[hit["recording_id"]]   # type content resolver recording
+            target = target_recordings[hit["index"]]           # troi recordings
+        
+            if local_recording["file_id_type"] == FileIdType.FILE_PATH:
+                target.musicbrainz["filename"] = local_recording["file_id"]
+            if local_recording["file_id_type"] == FileIdType.SUBSONIC_ID:
+                target.musicbrainz["subsonic_id"] = local_recording["file_id"]
+
             print(bcolors.OKGREEN + ("%-5s" % hit["method"]) + bcolors.ENDC +
                   "  %-40s %-40s %-40s" % (artist_recording["recording_name"][:39], "",
                                            artist_recording["artist_name"][:39]))
-            print("       %-40s %-40s %-40s" % (rec["recording_name"][:39],
-                                                rec["release_name"][:39],
-                                                rec["artist_name"][:39]))
+            print("       %-40s %-40s %-40s" % (local_recording["recording_name"][:39],
+                                                local_recording["release_name"][:39],
+                                                local_recording["artist_name"][:39]))
+            resolved += 1
 
-        if len(results) == 0:
+        if resolved == 0:
             print("Sorry, but no tracks could be resolved, no playlist generated.")
             return []
 
-        print(f'\n{len(recordings)} recordings resolved, {len(artist_recording_data) - len(recordings)} not resolved.')
-
-        return results
+        print(f'\n{resolved} recordings resolved, {failed} not resolved.')
+        return playlist

--- a/lb_content_resolver/lb_radio.py
+++ b/lb_content_resolver/lb_radio.py
@@ -68,7 +68,7 @@ class ListenBrainzRadioLocal:
         # Now filter out the tracks that were not matched
         filtered = []
         for rec in playlist.playlists[0].recordings:
-            if "subsonic_id" in rec.musicbrainz or "fileame" in rec.musicbrainz:
+            if "subsonic_id" in rec.musicbrainz or "filename" in rec.musicbrainz:
                 filtered.append(rec)
 
         playlist.playlists[0].recordings = filtered

--- a/lb_content_resolver/lb_radio.py
+++ b/lb_content_resolver/lb_radio.py
@@ -40,8 +40,7 @@ class ListenBrainzRadioLocal:
             return None
 
         if playlist == None:
-            print("Your prompt generated an empty playlist.")
-            return {"playlist": {"track": []}}
+            return playlist
 
         # Resolve any tracks that have not been resolved to a subsonic_id or a local file
         self.resolve_playlist(match_threshold, playlist)
@@ -62,8 +61,11 @@ class ListenBrainzRadioLocal:
         if not recordings:
             return
 
-        # Use the content resolver to resolve the recordings
-        self.resolve_recordings(match_threshold, recordings)
+        # Use the content resolver to resolve the recordings in situ
+        cr = ContentResolver()
+        pe = PlaylistElement()
+        pe.playlists = [ Playlist(recordings=recordings) ]
+        cr.resolve_playlist(match_threshold, pe)
 
         # Now filter out the tracks that were not matched
         filtered = []
@@ -72,21 +74,3 @@ class ListenBrainzRadioLocal:
                 filtered.append(rec)
 
         playlist.playlists[0].recordings = filtered
-
-    def resolve_recordings(self, match_threshold, recordings):
-        """ Use the content resolver to resolve the given recordings """
-
-        cr = ContentResolver()
-        pe = PlaylistElement()
-        pe.playlists = [ Playlist(recordings=recordings) ]
-        resolved_playlist = cr.resolve_playlist(match_threshold, pe)
-
-#        for i, t_recording in enumerate(recordings):
-#            if resolved_playlist.playlists[0].recordings[i] is not None:
-#                if resolved[i]["file_id_type"].value == FileIdType.SUBSONIC_ID.value:
-#                    t_recording.musicbrainz["subsonic_id"] = resolved[i]["file_id"]
-#
-#                if resolved[i]["file_id_type"].value == FileIdType.FILE_PATH.value:
-#                    t_recording.musicbrainz["filename"] = resolved[i]["file_id"]
-#
-#                t_recording.duration = resolved[i]["duration"]

--- a/lb_content_resolver/playlist.py
+++ b/lb_content_resolver/playlist.py
@@ -18,6 +18,15 @@ def read_jspf_playlist(jspf_file):
     return playlist_element
 
 
+def write_jspf_playlist(jspf_file, jspf):
+    """
+        Write a JSPF playlist to disk.
+    """
+
+    with open(jspf_file, "w") as f:
+        f.write(json.dumps(jspf.get_jspf()))
+
+
 def write_m3u_playlist(file_name, playlist_element):
     """
        Given a Troi playlist, write an m3u playlist to disk.

--- a/lb_content_resolver/playlist.py
+++ b/lb_content_resolver/playlist.py
@@ -1,5 +1,7 @@
 import json
 
+from troi.playlist import _deserialize_from_jspf, PlaylistElement
+
 
 def read_jspf_playlist(jspf_file):
     """
@@ -7,40 +9,26 @@ def read_jspf_playlist(jspf_file):
     """
 
     with open(jspf_file, "r") as f:
-        js = f.read()
+        jspf = f.read()
 
-    return json.loads(js)
+    playlist = _deserialize_from_jspf(json.loads(jspf))
+    playlist_element = PlaylistElement()
+    playlist_element.playlists = [ playlist ]
+
+    return playlist_element
 
 
-def write_m3u_playlist_from_results(file_name, playlist_title, hits):
+def write_m3u_playlist(file_name, playlist_title, playlist):
     """
-       Given a list of Recordings, write an m3u playlist.
+       Given a Troi playlist, write an m3u playlist to disk.
     """
 
-    # TODO: Ensure we dont call this with subsonic ids
     with open(file_name, "w") as m3u:
         m3u.write("#EXTM3U\n")
         m3u.write("#EXTENC: UTF-8\n")
         m3u.write("#PLAYLIST %s\n" % playlist_title)
-        for rec in hits:
+        for rec in playlist.playlists[0].recordings:
             if rec is None:
                 continue
-            m3u.write("#EXTINF %d,%s\n" % (rec["duration"] / 1000, rec["recording_name"]))
-            m3u.write(rec["file_id"] + "\n")
-
-
-def write_m3u_playlist_from_jspf(file_name, jspf):
-    """
-       Given a jspf playlist, write an m3u playlist.
-    """
-
-    with open(file_name, "w") as m3u:
-        m3u.write("#EXTM3U\n")
-        m3u.write("#EXTENC: UTF-8\n")
-        m3u.write("#PLAYLIST %s\n" % jspf["playlist"]["title"])
-        for track in jspf["playlist"]["track"]:
-            if "location" not in track:
-                continue
-
-            m3u.write("#EXTINF %d,%s\n" % (track["duration"] / 1000, track["title"]))
-            m3u.write(track["location"] + "\n")
+            m3u.write("#EXTINF %d,%s\n" % (rec.duration / 1000, rec.name))
+            m3u.write(rec.musicbrainz["filename"] + "\n")

--- a/lb_content_resolver/playlist.py
+++ b/lb_content_resolver/playlist.py
@@ -18,17 +18,22 @@ def read_jspf_playlist(jspf_file):
     return playlist_element
 
 
-def write_m3u_playlist(file_name, playlist_title, playlist):
+def write_m3u_playlist(file_name, playlist_element):
     """
        Given a Troi playlist, write an m3u playlist to disk.
     """
 
+    playlist = playlist_element.playlists[0]
     with open(file_name, "w") as m3u:
         m3u.write("#EXTM3U\n")
         m3u.write("#EXTENC: UTF-8\n")
-        m3u.write("#PLAYLIST %s\n" % playlist_title)
-        for rec in playlist.playlists[0].recordings:
+        m3u.write("#PLAYLIST %s\n" % playlist.name)
+        for rec in playlist.recordings:
             if rec is None:
                 continue
-            m3u.write("#EXTINF %d,%s\n" % (rec.duration / 1000, rec.name))
+            if rec.duration is None:
+                duration = 0
+            else: 
+                duration = rec.duration / 1000
+            m3u.write("#EXTINF %d,%s\n" % (duration, rec.name))
             m3u.write(rec.musicbrainz["filename"] + "\n")

--- a/lb_content_resolver/subsonic.py
+++ b/lb_content_resolver/subsonic.py
@@ -234,9 +234,9 @@ class SubsonicDatabase(Database):
 
 
 
-    def upload_playlist(self, jspf):
+    def upload_playlist(self, playlist):
         """
-            Given a JSPF playlist, upload the playlist to the subsonic API.
+            Given a Troi playlist, upload the playlist to the subsonic API.
         """
 
         conn = self.connect()
@@ -244,12 +244,10 @@ class SubsonicDatabase(Database):
             return
 
         song_ids = []
-        for track in jspf["playlist"]["track"]:
+        for recording in playlist.playlists[0].recordings:
             try:
-                song_ids.append(
-                    track["extension"]["https://musicbrainz.org/doc/jspf#track"]["additional_metadata"]["subsonic_identifier"][33:])
+                song_ids.append(recording.musicbrainz["subsonic_id"])
             except KeyError:
                 continue
 
-        name = jspf["playlist"]["title"]
-        conn.createPlaylist(name=name, songIds=song_ids)
+        conn.createPlaylist(name=playlist.playlists[0].name, songIds=song_ids)

--- a/lb_content_resolver/troi/periodic_jams.py
+++ b/lb_content_resolver/troi/periodic_jams.py
@@ -38,4 +38,4 @@ class LocalPeriodicJams(ListenBrainzRadioLocal):
         # Resolve any tracks that have not been resolved to a subsonic_id or a local file
         self.resolve_playlist(self.match_threshold, playlist)
 
-        return playlist.get_jspf() if playlist is not None else {"playlist": {"track": []}}
+        return playlist

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,3 @@ requests
 py-sonic@git+https://github.com/mayhem/py-sonic.git@int-vs-string
 tqdm
 troi@git+https://github.com/metabrainz/troi-recommendation-playground.git@lb-local
-icecream

--- a/resolve.py
+++ b/resolve.py
@@ -202,9 +202,11 @@ def lb_radio(db_file, threshold, upload_to_subsonic, save_to_m3u, save_to_jspf, 
     db.open()
     r = ListenBrainzRadioLocal()
     playlist = r.generate(mode, prompt, threshold)
+    from icecream import ic
+    ic(playlist)
     try:
         _ = playlist.playlists[0].recordings[0]
-    except (KeyError, IndexError):
+    except (KeyError, IndexError, AttributeError):
         db.metadata_sanity_check(include_subsonic=upload_to_subsonic)
         return
 
@@ -229,7 +231,7 @@ def periodic_jams(db_file, threshold, upload_to_subsonic, save_to_m3u, save_to_j
     playlist = pj.generate()
     try:
         _ = playlist.playlists[0].recordings[0]
-    except (KeyError, IndexError):
+    except (KeyError, IndexError, AttributeError):
         db.metadata_sanity_check(include_subsonic=upload_to_subsonic)
         return
 

--- a/resolve.py
+++ b/resolve.py
@@ -16,7 +16,7 @@ from lb_content_resolver.top_tags import TopTags
 from lb_content_resolver.duplicates import FindDuplicates
 from lb_content_resolver.artist_search import LocalRecordingSearchByArtistService
 from lb_content_resolver.troi.periodic_jams import LocalPeriodicJams
-from lb_content_resolver.playlist import read_jspf_playlist, write_m3u_playlist_from_results, write_m3u_playlist_from_jspf
+from lb_content_resolver.playlist import read_jspf_playlist, write_m3u_playlist
 from lb_content_resolver.unresolved_recording import UnresolvedRecordingTracker
 from troi.playlist import PLAYLIST_TRACK_EXTENSION_URI
 
@@ -29,35 +29,30 @@ except ImportError:
 DEFAULT_CHUNKSIZE = 100
 
 
-def output_playlist(db, jspf, upload_to_subsonic, save_to_playlist, dont_ask):
-    if jspf is None:
-        return
-
-    import json
-    print(json.dumps(jspf, indent=2))
-    track = jspf["playlist"]["track"]
+def output_playlist(db, playlist, upload_to_subsonic, save_to_playlist, dont_ask):
+    recording = playlist.playlists[0].recordings[0]
     if upload_to_subsonic and config:
-        if track and config.SUBSONIC_HOST:
+        if recording and config.SUBSONIC_HOST:
             try:
-                _ = track[0]["extension"][PLAYLIST_TRACK_EXTENSION_URI]["additional_metadata"]["subsonic_identifier"]
+                _ = recording.musicbrainz["subsonic_id"]
             except KeyError:
                 print("Playlist does not appear to contain subsonic ids. Can't upload to subsonic.")
                 return
 
             if dont_ask or ask_yes_no_question("Upload via subsonic? (Y/n)"):
                 print("uploading playlist")
-                db.upload_playlist(jspf)
+                db.upload_playlist(playlist)
             return
 
     if save_to_playlist:
         try:
-            _ = track[0]["location"]
+            _ = recording.musicbrainz["filename"]
         except KeyError:
             print("Playlist does not appear to contain file paths. Can't write a local playlist.")
             return
         if dont_ask or ask_yes_no_question(f"Save to '{save_to_playlist}'? (Y/n)"):
             print("saving playlist")
-            write_m3u_playlist_from_jspf(save_to_playlist, jspf)
+            write_m3u_playlist(save_to_playlist, playlist)
 
         return
 
@@ -171,12 +166,12 @@ def subsonic(db_file):
 def playlist(db_file, threshold, upload_to_subsonic, save_to_playlist, dont_ask, jspf_playlist):
     """ Resolve a JSPF file with MusicBrainz recording MBIDs to files in the local collection"""
     db_file = db_file_check(db_file)
-    db = Database(db_file)
+    db = SubsonicDatabase(db_file, config)
     db.open()
-    cr = ContentResolver()
-    jspf = read_jspf_playlist(jspf_playlist)
-    results = cr.resolve_playlist(threshold, jspf_playlist=jspf)
-    output_playlist(db, jspf, upload_to_subsonic, save_to_playlist, dont_ask)
+    lbrl = ListenBrainzRadioLocal()
+    playlist = read_jspf_playlist(jspf_playlist)
+    lbrl.resolve_playlist(threshold, playlist)
+    output_playlist(db, playlist, upload_to_subsonic, save_to_playlist, dont_ask)
 
 
 @click.command()
@@ -193,12 +188,38 @@ def lb_radio(db_file, threshold, upload_to_subsonic, save_to_playlist, dont_ask,
     db = SubsonicDatabase(db_file, config)
     db.open()
     r = ListenBrainzRadioLocal()
-    jspf = r.generate(mode, prompt, threshold)
-    if len(jspf["playlist"]["track"]) == 0:
+    playlist = r.generate(mode, prompt, threshold)
+    try:
+        _ = playlist.playlists[0].recordings[0]
+    except (KeyError, IndexError):
         db.metadata_sanity_check(include_subsonic=upload_to_subsonic)
         return
 
-    output_playlist(db, jspf, upload_to_subsonic, save_to_playlist, dont_ask)
+    output_playlist(db, playlist, upload_to_subsonic, save_to_playlist, dont_ask)
+
+
+@click.command()
+@click.option("-d", "--db_file", help="Database file for the local collection", required=False, is_flag=False)
+@click.option('-t', '--threshold', default=.80)
+@click.option('-u', '--upload-to-subsonic', required=False, is_flag=True, default=False)
+@click.option('-p', '--save-to-playlist', required=False)
+@click.option('-y', '--dont-ask', required=False, is_flag=True, help="write playlist to m3u file")
+@click.argument('user_name')
+def periodic_jams(db_file, threshold, upload_to_subsonic, save_to_playlist, dont_ask, user_name):
+    "Generate a periodic jams playlist"
+    db_file = db_file_check(db_file)
+    db = SubsonicDatabase(db_file, config)
+    db.open()
+
+    pj = LocalPeriodicJams(user_name, threshold)
+    playlist = pj.generate()
+    try:
+        _ = playlist.playlists[0].recordings[0]
+    except (KeyError, IndexError):
+        db.metadata_sanity_check(include_subsonic=upload_to_subsonic)
+        return
+
+    output_playlist(db, playlist, upload_to_subsonic, save_to_playlist, dont_ask)
 
 
 @click.command()
@@ -225,27 +246,6 @@ def duplicates(db_file, exclude_different_release, verbose):
     fd = FindDuplicates(db)
     fd.print_duplicate_recordings(exclude_different_release, verbose)
 
-
-@click.command()
-@click.option("-d", "--db_file", help="Database file for the local collection", required=False, is_flag=False)
-@click.option('-t', '--threshold', default=.80)
-@click.option('-u', '--upload-to-subsonic', required=False, is_flag=True, default=False)
-@click.option('-p', '--save-to-playlist', required=False)
-@click.option('-y', '--dont-ask', required=False, is_flag=True, help="write playlist to m3u file")
-@click.argument('user_name')
-def periodic_jams(db_file, threshold, upload_to_subsonic, save_to_playlist, dont_ask, user_name):
-    "Generate a periodic jams playlist"
-    db_file = db_file_check(db_file)
-    db = SubsonicDatabase(db_file, config)
-    db.open()
-
-    pj = LocalPeriodicJams(user_name, threshold)
-    jspf = pj.generate()
-    if len(jspf["playlist"]["track"]) == 0:
-        db.metadata_sanity_check(include_subsonic=upload_to_subsonic)
-        return
-
-    output_playlist(db, jspf, upload_to_subsonic, save_to_playlist, dont_ask)
 
 
 @click.command()

--- a/resolve.py
+++ b/resolve.py
@@ -30,7 +30,12 @@ DEFAULT_CHUNKSIZE = 100
 
 
 def output_playlist(db, playlist, upload_to_subsonic, save_to_playlist, dont_ask):
-    recording = playlist.playlists[0].recordings[0]
+    try:
+        recording = playlist.playlists[0].recordings[0]
+    except (KeyError, IndexError):
+        print("Cannot save empty playlist.")
+        return
+
     if upload_to_subsonic and config:
         if recording and config.SUBSONIC_HOST:
             try:

--- a/resolve.py
+++ b/resolve.py
@@ -33,6 +33,8 @@ def output_playlist(db, jspf, upload_to_subsonic, save_to_playlist, dont_ask):
     if jspf is None:
         return
 
+    import json
+    print(json.dumps(jspf, indent=2))
     track = jspf["playlist"]["track"]
     if upload_to_subsonic and config:
         if track and config.SUBSONIC_HOST:
@@ -162,9 +164,11 @@ def subsonic(db_file):
 @click.command()
 @click.option("-d", "--db_file", help="Database file for the local collection", required=False, is_flag=False)
 @click.option('-t', '--threshold', default=.80)
+@click.option('-u', '--upload-to-subsonic', required=False, is_flag=True)
+@click.option('-p', '--save-to-playlist', required=False)
+@click.option('-y', '--dont-ask', required=False, is_flag=True, help="write playlist to m3u file")
 @click.argument('jspf_playlist')
-@click.argument('m3u_playlist')
-def playlist(db_file, threshold, jspf_playlist, m3u_playlist):
+def playlist(db_file, threshold, upload_to_subsonic, save_to_playlist, dont_ask, jspf_playlist):
     """ Resolve a JSPF file with MusicBrainz recording MBIDs to files in the local collection"""
     db_file = db_file_check(db_file)
     db = Database(db_file)
@@ -172,7 +176,7 @@ def playlist(db_file, threshold, jspf_playlist, m3u_playlist):
     cr = ContentResolver()
     jspf = read_jspf_playlist(jspf_playlist)
     results = cr.resolve_playlist(threshold, jspf_playlist=jspf)
-    write_m3u_playlist_from_results(m3u_playlist, jspf["playlist"]["title"], results)
+    output_playlist(db, jspf, upload_to_subsonic, save_to_playlist, dont_ask)
 
 
 @click.command()
@@ -191,7 +195,6 @@ def lb_radio(db_file, threshold, upload_to_subsonic, save_to_playlist, dont_ask,
     r = ListenBrainzRadioLocal()
     jspf = r.generate(mode, prompt, threshold)
     if len(jspf["playlist"]["track"]) == 0:
-        print(upload_to_subsonic)
         db.metadata_sanity_check(include_subsonic=upload_to_subsonic)
         return
 

--- a/resolve.py
+++ b/resolve.py
@@ -49,11 +49,12 @@ def output_playlist(db, playlist, upload_to_subsonic, save_to_m3u, save_to_jspf,
                 db.upload_playlist(playlist)
             return
 
-    try:
-        _ = recording.musicbrainz["filename"]
-    except KeyError:
-        print("Playlist does not appear to contain file paths. Can't write a local playlist.")
-        return
+    if save_to_m3u or save_to_jspf:
+        try:
+            _ = recording.musicbrainz["filename"]
+        except KeyError:
+            print("Playlist does not appear to contain file paths. Can't write a local playlist.")
+            return
 
     if save_to_m3u:
         if dont_ask or ask_yes_no_question(f"Save to '{save_to_m3u}'? (Y/n)"):
@@ -67,7 +68,7 @@ def output_playlist(db, playlist, upload_to_subsonic, save_to_m3u, save_to_jspf,
             write_jspf_playlist(save_to_jspf, playlist)
         return
 
-    print("Playlist displayed, but not saved. Use -p or -u options to save/upload playlists.")
+    print("Playlist displayed, but not saved. Use -j, -m or -u options to save/upload playlists.")
 
 
 def db_file_check(db_file):
@@ -202,8 +203,6 @@ def lb_radio(db_file, threshold, upload_to_subsonic, save_to_m3u, save_to_jspf, 
     db.open()
     r = ListenBrainzRadioLocal()
     playlist = r.generate(mode, prompt, threshold)
-    from icecream import ic
-    ic(playlist)
     try:
         _ = playlist.playlists[0].recordings[0]
     except (KeyError, IndexError, AttributeError):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(
-    name='ListenBrainz Content Resolver',
+    name='lb-content-resolver',
     version='1.0.0',
     url='https://github.com/metabrainz/listenbrainz-content-resolver.git',
     author='Robert Kaye',
@@ -23,9 +23,15 @@ setup(
         "Click==8.1.3",
         "mutagen==1.46.0",
         "nmslib==2.1.1",
+        "peewee==3.16.2",
+        "py-sonic@git+https://github.com/mayhem/py-sonic.git@int-vs-string",
+        "requests",
         "regex==2023.6.3",
+        "tqdm",
+        "troi@git+https://github.com/metabrainz/troi-recommendation-playground.git@lb-local",
         "scikit-learn==1.2.1",
         "Unidecode==1.3.6",
+        "lb_matching_tools@git+https://github.com/metabrainz/listenbrainz-matching-tools.git@v-2023-07-19.0"
     ],
     use_scm_version=True,
     setup_requires=['setuptools_scm'],


### PR DESCRIPTION
This PR finishes the support for resolving playlists and letting the user decide if they should be written to jspf, m3u or subsonic. At the same time it refactors internals and standardizes on the Troi PlaylistElement object for internal playlist representation. Now JSPF is only used for reading/writing playlists. More comments, improved variable naming, less duplication and other tiny bits of cleanup.